### PR TITLE
feat: show global shop closure banner and shop status

### DIFF
--- a/src/modules/home/HomePage.css
+++ b/src/modules/home/HomePage.css
@@ -4,6 +4,34 @@
     background: #f8fafc;
 }
 
+.global-closure-banner {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    margin: 12px 16px;
+    padding: 14px 16px;
+    background: #fff5f5;
+    border: 1px solid #fecaca;
+    color: #991b1b;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.global-closure-banner strong {
+    color: #991b1b;
+}
+
+.global-closure-icon {
+    font-size: 1.4rem;
+    line-height: 1.2;
+}
+
+.global-closure-reason {
+    margin-top: 4px;
+    font-size: 0.9rem;
+    color: #7f1d1d;
+}
+
 /* Loading State */
 .loading-state {
     display: flex;

--- a/src/modules/home/HomePage.js
+++ b/src/modules/home/HomePage.js
@@ -33,6 +33,7 @@ const HomePage = () => {
     const { indexLoaded, searchLocal } = useSearch();
     const [suggestions, setSuggestions] = useState([]);
     const [showSuggestions, setShowSuggestions] = useState(false);
+    const [globalClosure, setGlobalClosure] = useState({ isClosed: false });
 
     // Sample shops as fallback
     const sampleShops = [
@@ -156,6 +157,9 @@ const HomePage = () => {
             } else if (response.data.shops) {
                 shopsData = response.data.shops;
             }
+
+            const closureInfo = response.data?.data?.globalClosure || response.data?.globalClosure || { isClosed: false };
+            setGlobalClosure(closureInfo);
 
             if (shopsData.length > 0) {
                 // Sort shops: highest orders first, then open shops, then number of items
@@ -479,6 +483,22 @@ const HomePage = () => {
     return (
         <div className="home-container">
             <PermanentNotices />
+            {globalClosure?.isClosed && (
+                <div className="global-closure-banner">
+                    <span className="global-closure-icon">🚫</span>
+                    <div>
+                        <strong>All shops are currently closed.</strong>{' '}
+                        {globalClosure.mode === 'manual' && 'Please check back later.'}
+                        {globalClosure.mode === 'until_time' && globalClosure.reopenAt && (
+                            <>Reopening at {new Date(globalClosure.reopenAt).toLocaleString()}.</>
+                        )}
+                        {globalClosure.mode === 'next_day' && globalClosure.reopenAt && (
+                            <>Reopening on {new Date(globalClosure.reopenAt).toLocaleDateString()}.</>
+                        )}
+                        {globalClosure.reason ? <div className="global-closure-reason">{globalClosure.reason}</div> : null}
+                    </div>
+                </div>
+            )}
             {/* Header Section */}
             <div className="home-header">
                 <div className="header-content">

--- a/src/modules/shop/ShopPage.js
+++ b/src/modules/shop/ShopPage.js
@@ -21,6 +21,7 @@ const ShopPage = () => {
     const [showMenu, setShowMenu] = useState(false);
     const { addToCart, selectedShop, setSelectedShop } = useCart();
     const productRefsMap = useRef({});
+    const [globalClosure, setGlobalClosure] = useState({ isClosed: false });
 
     useEffect(() => {
         const fetchShopAndProducts = async () => {
@@ -104,6 +105,9 @@ const ShopPage = () => {
                     });
 
                     setShop(shopData);
+
+                    const closureInfo = shopResult.data?.globalClosure || shopResult.data?.data?.globalClosure || { isClosed: false };
+                    setGlobalClosure(closureInfo);
                 } else {
                     console.error('Failed to fetch shop:', shopResult.message);
                     setShop(null);
@@ -319,6 +323,15 @@ const ShopPage = () => {
 
     // Helper function to get shop status message
     const getShopStatusMessage = (shop) => {
+        if (globalClosure?.isClosed) {
+            let message = 'Temporarily closed';
+            if (globalClosure.mode === 'until_time' && globalClosure.reopenAt) {
+                message = `Closed until ${new Date(globalClosure.reopenAt).toLocaleString()}`;
+            } else if (globalClosure.mode === 'next_day' && globalClosure.reopenAt) {
+                message = `Closed — reopens ${new Date(globalClosure.reopenAt).toLocaleDateString()}`;
+            }
+            return { isOpen: false, message };
+        }
         if (!shop?.operatingHours) return { isOpen: true, message: 'Open' };
 
         // Get current time in IST (Indian Standard Time)


### PR DESCRIPTION
Reads globalClosure metadata from the shops API and displays a banner on the home page with the reopen time. While a closure is active, the shop detail page shows Closed with the reopen window instead of computing status from operating hours.