### PR TITLE
fix(auth): make midnight logout actually fire reliably

### DIFF
--- a/src/modules/auth/MidnightLogoutHandler.js
+++ b/src/modules/auth/MidnightLogoutHandler.js
@@ -1,64 +1,57 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 
+/**
+ * Logs the signed-in customer out at the next midnight (local time).
+ *
+ * The previous version compared new Date().getDate() against a ref that was
+ * reset on every effect re-run, so a re-render just after midnight made the
+ * check pass as "same day" and the logout never fired. This version locks in a
+ * single midnight *timestamp* and simply checks whether the clock has reached
+ * it — reliable across re-renders, and across tab sleep/wake because a 30s
+ * interval re-checks the real time (not just a one-shot timer).
+ */
 const MidnightLogoutHandler = () => {
-    const { user, logout } = useAuth();
-    const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const targetRef = useRef(null);
 
-    // Track the date when the component mounts or when a new day starts
-    const currentDayRef = useRef(new Date().getDate());
+  useEffect(() => {
+    if (!user) {
+      targetRef.current = null;
+      return undefined;
+    }
 
-    useEffect(() => {
-        // Only run if user is logged in
-        if (!user) return;
+    // Lock in the upcoming midnight ONCE. Do not recompute it on later re-runs,
+    // otherwise a re-render right after midnight would push the target to the
+    // next day and skip the logout.
+    if (targetRef.current == null) {
+      const next = new Date();
+      next.setHours(24, 0, 0, 0); // start of the next local day
+      targetRef.current = next.getTime();
+    }
 
-        // Reset the tracker if the user logging in on a new day
-        currentDayRef.current = new Date().getDate();
+    const check = () => {
+      if (targetRef.current != null && Date.now() >= targetRef.current) {
+        targetRef.current = null;
+        logout();
+        navigate('/login');
+      }
+    };
 
-        const checkAndLogout = () => {
-            const now = new Date();
+    // Precise one-shot at the target, plus a safety poll (covers sleep/wake and
+    // any timer throttling while the tab is in the background).
+    const timeoutId = setTimeout(check, Math.max(0, targetRef.current - Date.now()) + 500);
+    const intervalId = setInterval(check, 30000);
 
-            // Check if the actual date has changed vs what we stored
-            if (now.getDate() !== currentDayRef.current) {
-                console.log('🌑 Date boundary crossed (midnight). Logging out user...');
-                logout();
-                navigate('/login');
-                return true; // Logout triggered
-            }
-            return false;
-        };
+    return () => {
+      clearTimeout(timeoutId);
+      clearInterval(intervalId);
+    };
+  }, [user, logout, navigate]);
 
-        // Initial check on mount
-        if (checkAndLogout()) return;
-
-        // Calculate time until next exact midnight for the timeout
-        const now = new Date();
-        const midnight = new Date(now);
-        midnight.setHours(24, 0, 0, 0); // Next midnight
-        const timeToMidnight = midnight.getTime() - now.getTime();
-
-        console.log(`⏳ Auto-logout roughly scheduled in ${(timeToMidnight / 1000 / 60 / 60).toFixed(2)} hours`);
-
-        // Timeout fires exactly at midnight if the computer stays awake
-        const timeoutId = setTimeout(() => {
-            console.log('🌑 Midnight timeout triggered');
-            checkAndLogout(); // Verify date has actually changed
-        }, timeToMidnight);
-
-        // Robust interval check: fires every 1 minute
-        // This instantly catches if the computer wakes up from sleep AFTER midnight
-        const intervalId = setInterval(() => {
-            checkAndLogout();
-        }, 60000);
-
-        return () => {
-            clearTimeout(timeoutId);
-            clearInterval(intervalId);
-        };
-    }, [user, logout, navigate]);
-
-    return null; // This component renders nothing
+  return null;
 };
 
 export default MidnightLogoutHandler;


### PR DESCRIPTION
The handler reset its day tracker on every effect re-run and compared getDate() against it, so a re-render just after midnight read as the "same day" and the logout never triggered.

Lock in a single upcoming-midnight timestamp and check the real clock against it via a one-shot timer plus a 30s safety poll — so it fires dependably across re-renders and tab sleep/wake.

## Summary

<!-- What does this PR do, and why? 1-3 sentences. -->

## Changes

<!-- Bullet list of the notable changes -->

-

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Docs

## Testing

<!-- How did you verify this works? -->

- [x] Ran `npm run lint`
- [x] Tested locally

## Checklist

- [x] No leftover debug code (`console.log`, `debugger`) or commented-out blocks
- [x] No secrets, credentials, or real `.env` values committed
- [x] Pre-commit hooks passed (no `--no-verify`)
